### PR TITLE
feat: standalone metrics server

### DIFF
--- a/.changeset/standalone-metrics.md
+++ b/.changeset/standalone-metrics.md
@@ -1,0 +1,10 @@
+---
+"@d13z/astro-prometheus-integration": minor
+---
+
+Added standalone metrics server option that allows running the Prometheus metrics endpoint on a separate server instance. This feature enables better separation of concerns and more flexible deployment options.
+
+- Added standalone metrics server configuration option
+- Added integration tests for standalone metrics functionality
+- Added default metrics test coverage
+- Improved package exports by removing test files from npm package 

--- a/packages/astro-prometheus-node-integration/env.d.ts
+++ b/packages/astro-prometheus-node-integration/env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="astro/client" />
+
+declare global {
+	var __astroPromStandaloneServerStarted: boolean;
+}
+
+export {};

--- a/packages/astro-prometheus-node-integration/package.json
+++ b/packages/astro-prometheus-node-integration/package.json
@@ -29,7 +29,12 @@
 			"default": "./dist/index.js"
 		}
 	},
-	"files": ["dist"],
+	"files": [
+		"dist/**/*",
+		"!dist/**/*.test.js",
+		"!dist/**/*.test.d.ts",
+		"!dist/**/*.test.js.map"
+	],
 	"scripts": {
 		"dev": "tsup --watch",
 		"build": "tsup",

--- a/packages/astro-prometheus-node-integration/src/metrics/index.test.ts
+++ b/packages/astro-prometheus-node-integration/src/metrics/index.test.ts
@@ -2,7 +2,12 @@
 import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import { Counter, Registry } from "prom-client";
 import { beforeEach, describe, expect, it } from "vitest";
-import { initRegistry } from "./index.js";
+import {
+	HTTP_REQUESTS_TOTAL,
+	HTTP_REQUEST_DURATION,
+	HTTP_SERVER_DURATION_SECONDS,
+	initRegistry,
+} from "./index.js";
 
 describe("initRegistry", () => {
 	let registry: Registry;
@@ -22,6 +27,24 @@ describe("initRegistry", () => {
 
 		// Check that at least one default metric is present
 		expect(metrics.some((m: any) => m.name.startsWith("process_"))).toBe(true);
+	});
+
+	it("check that all custom metrics are registered", async () => {
+		initRegistry({
+			register: registry,
+			registerContentType: "PROMETHEUS",
+		});
+
+		const metricsText = await registry.metrics();
+		const metrics = parsePrometheusTextFormat(metricsText) as any[];
+
+		expect(metrics.some((m: any) => m.name === HTTP_REQUESTS_TOTAL)).toBe(true);
+		expect(metrics.some((m: any) => m.name === HTTP_REQUEST_DURATION)).toBe(
+			true,
+		);
+		expect(
+			metrics.some((m: any) => m.name === HTTP_SERVER_DURATION_SECONDS),
+		).toBe(true);
 	});
 
 	it("applies prefix to all metrics", async () => {

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
@@ -42,7 +42,7 @@ describe("startStandaloneMetricsServer", () => {
 		};
 
 		// Reset global flag for each test
-		(globalThis as any).__astroPromStandaloneServerStarted = false;
+		globalThis.__astroPromStandaloneServerStarted = false;
 	});
 
 	it("responds with metrics at the configured URL and port", async () => {

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
@@ -1,0 +1,105 @@
+import http from "node:http";
+import { Counter, Registry } from "prom-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startStandaloneMetricsServer } from "./standalone-metrics-server.js";
+
+function getFreePort(): Promise<number> {
+	return new Promise((resolve) => {
+		const srv = http.createServer();
+		srv.listen(0, () => {
+			const port = (srv.address() as any).port;
+			srv.close(() => resolve(port));
+		});
+	});
+}
+
+describe("startStandaloneMetricsServer", () => {
+	let registry: Registry;
+	let port: number;
+	let metricsUrl: string;
+	let logger: any;
+
+	beforeEach(async () => {
+		registry = new Registry();
+		// Add a test metric
+		const counter = new Counter({
+			name: "test_counter",
+			help: "A test counter",
+			registers: [registry],
+		});
+		counter.inc(42);
+
+		port = await getFreePort();
+		metricsUrl = "/test-metrics";
+		logger = {
+			info: vi.fn(),
+			warn: () => {},
+			error: () => {},
+			debug: () => {},
+			options: {},
+			label: "test",
+			fork: () => logger,
+		};
+
+		// Reset global flag for each test
+		(globalThis as any).__astroPromStandaloneServerStarted = false;
+	});
+
+	it("responds with metrics at the configured URL and port", async () => {
+		startStandaloneMetricsServer({
+			register: registry,
+			port,
+			metricsUrl,
+			logger,
+		});
+
+		// Wait a bit for the server to start
+		await new Promise((r) => setTimeout(r, 100));
+
+		const res = await fetch(`http://localhost:${port}${metricsUrl}`);
+		expect(res.status).toBe(200);
+		const text = await res.text();
+		expect(text).toContain("test_counter");
+		expect(text).toContain("42");
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`Standalone metrics server listening on port ${port}`,
+			),
+		);
+	});
+
+	it("returns 404 for non-metrics URLs", async () => {
+		startStandaloneMetricsServer({
+			register: registry,
+			port,
+			metricsUrl,
+			logger,
+		});
+
+		await new Promise((r) => setTimeout(r, 100));
+
+		const res = await fetch(`http://localhost:${port}/not-metrics`);
+		expect(res.status).toBe(404);
+		const text = await res.text();
+		expect(text).toBe("Not found");
+	});
+
+	it("does not start multiple servers", async () => {
+		startStandaloneMetricsServer({
+			register: registry,
+			port,
+			metricsUrl,
+			logger,
+		});
+		startStandaloneMetricsServer({
+			register: registry,
+			port,
+			metricsUrl,
+			logger,
+		});
+
+		await new Promise((r) => setTimeout(r, 100));
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
@@ -1,0 +1,49 @@
+import { createServer } from "node:http";
+import type { AstroIntegrationLogger } from "astro";
+import type { Registry } from "prom-client";
+interface StandaloneMetricsServerOptions {
+	register: Registry;
+	port: number;
+	metricsUrl: string;
+	logger: AstroIntegrationLogger;
+}
+
+/**
+ * Starts a standalone HTTP server exposing Prometheus metrics at /metrics.
+ * @param options - Configuration for the server (register, port, content type)
+ */
+export function startStandaloneMetricsServer({
+	register,
+	port,
+	metricsUrl,
+	logger,
+}: StandaloneMetricsServerOptions) {
+	// Only start one server per process
+	if ((globalThis as any).__astroPromStandaloneServerStarted) {
+		return;
+	}
+	(globalThis as any).__astroPromStandaloneServerStarted = true;
+
+	const server = createServer(async (req, res) => {
+		if (req.method === "GET" && req.url === metricsUrl) {
+			try {
+				const metrics = await register.metrics();
+				res.writeHead(200, {
+					"Content-Type": register.contentType || "text/plain",
+				});
+				res.end(metrics);
+			} catch (err) {
+				res.writeHead(500);
+				res.end("Error generating metrics");
+			}
+			return;
+		}
+		res.writeHead(404);
+		res.end("Not found");
+	});
+
+	server.listen(port, () => {
+		// eslint-disable-next-line no-console
+		logger.info(`Standalone metrics server listening on port ${port}`);
+	});
+}

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
@@ -19,10 +19,10 @@ export function startStandaloneMetricsServer({
 	logger,
 }: StandaloneMetricsServerOptions) {
 	// Only start one server per process
-	if ((globalThis as any).__astroPromStandaloneServerStarted) {
+	if (globalThis.__astroPromStandaloneServerStarted) {
 		return;
 	}
-	(globalThis as any).__astroPromStandaloneServerStarted = true;
+	globalThis.__astroPromStandaloneServerStarted = true;
 
 	const server = createServer(async (req, res) => {
 		if (req.method === "GET" && req.url === metricsUrl) {

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -14,8 +14,12 @@ export default defineConfig({
 	integrations: [
 		prometheusNodeIntegration({
 			enabled: true, // explicitly enable it
-			metricsUrl: "/metrics", // explicitly set the metrics URL
+			metricsUrl: "/_/metrics", // explicitly set the metrics URL
 			registerContentType: "PROMETHEUS",
+			standaloneMetrics: {
+				enabled: true,
+				port: 6080,
+			},
 			collectDefaultMetricsConfig: {
 				prefix: "myapp_", // All metrics will be prefixed with "myapp_"
 				labels: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "nodemon -w ../packages/astro-prometheus-node-integration/dist -e js,mjs,cjs,json --exec \"astro dev\"",
+		"dev": "nodemon -w ../packages/astro-prometheus-node-integration/dist -e js,mjs,cjs,json -w ./astro.config.mts --exec \"astro dev\"",
 		"start": "astro dev",
 		"build": "astro check && astro build",
 		"preview": "astro preview",


### PR DESCRIPTION
This pull request introduces a new feature to the `@d13z/astro-prometheus-integration` package: the ability to run a standalone Prometheus metrics server. This feature provides better separation of concerns and more flexible deployment options. Additionally, the pull request includes updates to documentation, configuration, and tests to support this new functionality.

### New Feature: Standalone Metrics Server
* Added the `standaloneMetrics` configuration option, allowing users to run a separate HTTP server for Prometheus metrics. This disables the default Astro route and starts a Node.js server on the specified port. [[1]](diffhunk://#diff-a60f5d70d9bebaaad975e54933575f3bb55199960fc1412b482384a83f64cb36R25-R37) [[2]](diffhunk://#diff-e81d01cf5a2cfb4ac6367b8e5370e64f920084af3271341dda275ef1bc32a41bR1-R49)
* Updated the README to document the new `standaloneMetrics` option, including usage examples and configuration details. [[1]](diffhunk://#diff-7c8244d347b09fcb2182839991a5f8b765bfe960b9163295f09e53b640a724eeR129) [[2]](diffhunk://#diff-7c8244d347b09fcb2182839991a5f8b765bfe960b9163295f09e53b640a724eeR179-R216)
* Added a new module, `standalone-metrics-server.ts`, to handle the standalone server logic.

### Integration and Configuration Updates
* Modified the integration setup to conditionally start the standalone metrics server if the `standaloneMetrics.enabled` option is set to `true`. Otherwise, the default Astro route is injected. [[1]](diffhunk://#diff-a60f5d70d9bebaaad975e54933575f3bb55199960fc1412b482384a83f64cb36L40-R54) [[2]](diffhunk://#diff-a60f5d70d9bebaaad975e54933575f3bb55199960fc1412b482384a83f64cb36R68-R94)
* Updated the playground configuration to demonstrate the use of the `standaloneMetrics` option.

### Testing Enhancements
* Added integration tests for the standalone metrics server, including cases for valid metrics requests, invalid routes, and prevention of multiple server instances.
* Improved test coverage for default metrics and custom metrics registration. [[1]](diffhunk://#diff-b0873376e6d5fc6679b6102a5439570f684b5718f190e1811298a0f55d207276L5-R10) [[2]](diffhunk://#diff-b0873376e6d5fc6679b6102a5439570f684b5718f190e1811298a0f55d207276R32-R49)

### Documentation and Package Improvements
* Improved package exports by excluding test files from the npm package.
* Added a changeset file to document the new feature and its impact.