### PR TITLE
Move Standalone Metrics Server Execution to Middleware

### DIFF
--- a/.changeset/deep-days-prove.md
+++ b/.changeset/deep-days-prove.md
@@ -1,0 +1,7 @@
+---
+"astro-prometheus-node-integration": minor
+---
+
+Move standalone metrics server execution to middleware
+
+The logic for starting the standalone Prometheus metrics server was moved from the integration setup to the middleware. This ensures the standalone server is started when running Astro in standalone Node.js mode, not just during dev, preview, or build. Type definitions and tests were updated accordingly. This change ensures metrics are always available in standalone deployments and prevents multiple server instances from being started.

--- a/packages/astro-prometheus-node-integration/env.d.ts
+++ b/packages/astro-prometheus-node-integration/env.d.ts
@@ -1,7 +1,8 @@
+import type { z } from "astro/zod";
 /// <reference types="astro/client" />
+import type { integrationSchema } from "./src/integration.ts";
 
 declare global {
 	var __astroPromStandaloneServerStarted: boolean;
+	var __PROMETHEUS_OPTIONS__: z.infer<typeof integrationSchema>;
 }
-
-export {};

--- a/packages/astro-prometheus-node-integration/src/middleware/prometheus-middleware.test.ts
+++ b/packages/astro-prometheus-node-integration/src/middleware/prometheus-middleware.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { initRegistry } from "../metrics/index.js";
 import { createPrometheusMiddleware } from "./prometheus-middleware.js";
 
+// Define a default structure for the global options before module import
+// globalThis.__PROMETHEUS_OPTIONS__ = { ... removed ... };
+
 function createMockContext(method = "GET", path = "/test") {
 	return {
 		request: { method },
@@ -22,6 +25,18 @@ describe("createPrometheusMiddleware integration", () => {
 			registerContentType: "PROMETHEUS",
 		});
 		middleware = createPrometheusMiddleware(registry);
+		// Set specific options for each test run
+		globalThis.__PROMETHEUS_OPTIONS__ = {
+			metricsUrl: "/metrics",
+			registerContentType: "PROMETHEUS",
+			enabled: true,
+			standaloneMetrics: {
+				enabled: false,
+				port: 9090,
+			},
+			// Ensure collectDefaultMetricsConfig is explicitly undefined or set if needed per test
+			collectDefaultMetricsConfig: undefined,
+		};
 	});
 
 	it("increments http_requests_total", async () => {

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
@@ -1,11 +1,9 @@
 import { createServer } from "node:http";
-import type { AstroIntegrationLogger } from "astro";
 import type { Registry } from "prom-client";
 interface StandaloneMetricsServerOptions {
 	register: Registry;
 	port: number;
 	metricsUrl: string;
-	logger: AstroIntegrationLogger;
 }
 
 /**
@@ -16,7 +14,6 @@ export function startStandaloneMetricsServer({
 	register,
 	port,
 	metricsUrl,
-	logger,
 }: StandaloneMetricsServerOptions) {
 	// Only start one server per process
 	if (globalThis.__astroPromStandaloneServerStarted) {
@@ -43,7 +40,15 @@ export function startStandaloneMetricsServer({
 	});
 
 	server.listen(port, () => {
-		// eslint-disable-next-line no-console
-		logger.info(`Standalone metrics server listening on port ${port}`);
+		const formattedTime = new Date().toLocaleTimeString("en-US", {
+			hour12: false,
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+		});
+
+		console.info(
+			`\x1b[90m${formattedTime}\x1b[0m \x1b[34m[astro-prometheus-node-integration]\x1b[0m Standalone metrics server listening on port ${port}`,
+		);
 	});
 }

--- a/packages/astro-prometheus-node-integration/vitest.config.ts
+++ b/packages/astro-prometheus-node-integration/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		setupFiles: ["./vitest.setup.ts"],
+		globals: true, // Optional: If you want Vitest globals like describe, it, etc.
+		environment: "node", // Or 'jsdom' if needed
+	},
+});

--- a/packages/astro-prometheus-node-integration/vitest.setup.ts
+++ b/packages/astro-prometheus-node-integration/vitest.setup.ts
@@ -1,0 +1,13 @@
+console.log("Vitest setup file loaded.");
+
+// Define a default structure for the global options before any tests run
+globalThis.__PROMETHEUS_OPTIONS__ = {
+	metricsUrl: "/metrics",
+	registerContentType: "PROMETHEUS",
+	enabled: true,
+	standaloneMetrics: {
+		enabled: false,
+		port: 9090,
+	},
+	collectDefaultMetricsConfig: undefined, // Add other potential fields if needed
+};


### PR DESCRIPTION
### Overview

This PR refactors the way the standalone Prometheus metrics server is started in the `astro-prometheus-node-integration` package. Previously, the logic to start the standalone server was placed within the integration setup hooks. However, code in integration hooks only runs during `astro dev`, `astro preview`, and at build time—not when running Astro as a standalone Node.js server. This led to the standalone metrics server not being available in production or custom Node.js deployments.

---

### What’s Changed

- **Standalone Server Execution Moved to Middleware**
  - The logic for starting the standalone Prometheus metrics server now resides in the middleware (`prometheus-middleware.ts`).
  - This ensures the server is started regardless of how Astro is run, including in standalone Node.js mode.

- **Integration Setup Refactored**
  - The integration setup no longer attempts to start the standalone server.
  - The integration now only injects the metrics route and middleware as appropriate.

- **Type Definitions Updated**
  - The global flag `__astroPromStandaloneServerStarted` and the Prometheus options type are now defined in `env.d.ts` to ensure type safety and prevent multiple server instances.

- **Test Coverage Improved**
  - Tests for the standalone metrics server (`standalone-metrics-server.test.ts`) and middleware (`prometheus-middleware.test.ts`) have been updated and expanded.
  - Tests ensure that:
    - The standalone server starts only once per process.
    - The server responds correctly at the configured metrics URL and port.
    - The middleware correctly starts the server and records metrics in all supported scenarios.

- **Configuration and Setup**
  - The Vitest setup and config files were updated to support the new middleware logic and global options.

---

### Motivation

- **Production Reliability**  
  The previous approach did not start the standalone metrics server when running Astro in standalone Node.js mode, which is a common production deployment scenario. Moving the logic to the middleware ensures metrics are always available, regardless of how the app is started.

- **Single Responsibility**  
  The middleware is now responsible for all runtime metrics logic, making the integration setup cleaner and easier to maintain.

- **Prevents Multiple Instances**  
  A global flag ensures that only one standalone metrics server is started per process, preventing port conflicts and duplicate metrics.

---

### How to Test

- Run Astro in all supported modes (`dev`, `preview`, and standalone Node.js) and verify that the metrics endpoint is available as expected.
- Run the updated test suite to ensure all metrics and server behaviors are covered.

---

### Related Issues

- Fixes the problem where metrics were not available in standalone Node.js deployments.
- Improves maintainability and testability of the integration.

---