### PR TITLE
fix: metrics page is static

### DIFF
--- a/packages/astro-prometheus-node-integration/src/routes/metrics.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/metrics.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
 import client from "prom-client";
 
+export const prerender = false;
+
 // Prometheus metrics endpoint for Astro
 export const GET: APIRoute = async () => {
 	try {


### PR DESCRIPTION
Disable static build for the metrics page.

cf: https://docs.astro.build/en/reference/routing-reference/#prerender