### PR TITLE
fix: update issues

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,23 +1,33 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
+	"$schema": "node_modules/@biomejs/biome/configuration_schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
 			"recommended": true,
 			"suspicious": {
 				"noExplicitAny": "warn"
+			},
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
 			}
 		}
 	},
 	"files": {
-		"ignore": ["dist", ".astro"]
+		"includes": ["**", "!**/dist", "!**/.astro"]
 	},
 	"overrides": [
 		{
-			"include": [
+			"includes": [
 				"**/*.test.ts",
 				"**/*.test.js",
 				"**/*.spec.ts",

--- a/demo/astro.config.mjs
+++ b/demo/astro.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
-import { defineConfig } from "astro/config";
 
 import node from "@astrojs/node";
+import { defineConfig } from "astro/config";
 
 import prometheusNodeIntegration from "astro-prometheus-node-integration";
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
 		"lint-staged": "^16.0.0"
 	},
 	"lint-staged": {
-		"*": ["biome check --write"]
+		"*": [
+			"biome check --write"
+		]
 	}
 }

--- a/packages/astro-prometheus-node-integration/src/integration.ts
+++ b/packages/astro-prometheus-node-integration/src/integration.ts
@@ -1,6 +1,7 @@
 // Integration for Astro Prometheus Node: defines the integration and its options schema using Zod
-import { defineIntegration } from "astro-integration-kit";
+
 import { z } from "astro/zod";
+import { defineIntegration } from "astro-integration-kit";
 import { metricsConfigSchema } from "./metrics/config.js";
 
 export const integrationSchema = z
@@ -61,6 +62,7 @@ export const integration = defineIntegration({
 						injectRoute({
 							pattern: options.metricsUrl,
 							entrypoint: new URL("./routes/metrics.js", import.meta.url),
+							prerender: false,
 						});
 					}
 					updateConfig({

--- a/packages/astro-prometheus-node-integration/src/metrics/index.test.ts
+++ b/packages/astro-prometheus-node-integration/src/metrics/index.test.ts
@@ -3,8 +3,8 @@ import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import { Counter, Registry } from "prom-client";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-	HTTP_REQUESTS_TOTAL,
 	HTTP_REQUEST_DURATION,
+	HTTP_REQUESTS_TOTAL,
 	HTTP_SERVER_DURATION_SECONDS,
 	initRegistry,
 } from "./index.js";

--- a/packages/astro-prometheus-node-integration/src/middleware/prometheus-middleware.ts
+++ b/packages/astro-prometheus-node-integration/src/middleware/prometheus-middleware.ts
@@ -2,8 +2,8 @@
 import { defineMiddleware } from "astro/middleware";
 import client from "prom-client";
 import {
-	HTTP_REQUESTS_TOTAL,
 	HTTP_REQUEST_DURATION,
+	HTTP_REQUESTS_TOTAL,
 	HTTP_SERVER_DURATION_SECONDS,
 	initRegistry,
 } from "../metrics/index.js";

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.test.ts
@@ -1,12 +1,12 @@
 import http from "node:http";
 import { Counter, Registry } from "prom-client";
 import {
-	type MockInstance,
 	afterEach,
 	beforeEach,
 	describe,
 	expect,
 	it,
+	type MockInstance,
 	vi,
 } from "vitest";
 import { startStandaloneMetricsServer } from "./standalone-metrics-server.js";

--- a/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
+++ b/packages/astro-prometheus-node-integration/src/routes/standalone-metrics-server.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import type { Registry } from "prom-client";
+
 interface StandaloneMetricsServerOptions {
 	register: Registry;
 	port: number;

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -1,8 +1,8 @@
 import node from "@astrojs/node";
 import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "astro/config";
 import { createResolver } from "astro-integration-kit";
 import { hmrIntegration } from "astro-integration-kit/dev";
-import { defineConfig } from "astro/config";
 
 // Import the named export 'integration'
 const { default: prometheusNodeIntegration } = await import(
@@ -17,7 +17,7 @@ export default defineConfig({
 			metricsUrl: "/_/metrics", // explicitly set the metrics URL
 			registerContentType: "PROMETHEUS",
 			standaloneMetrics: {
-				enabled: true,
+				enabled: false,
 				port: 6080,
 			},
 			collectDefaultMetricsConfig: {

--- a/playground/src/pages/test/throw-error.astro
+++ b/playground/src/pages/test/throw-error.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 throw new Error("Test error");
 ---
 


### PR DESCRIPTION
This PR addresses several issues and improvements:

- **Playground Integration:**  
  - Updates the playground's `astro.config.mts` to explicitly disable the standalone metrics server (`standaloneMetrics.enabled: false`) for better local development experience.
  - Ensures the `/test/throw-error.astro` page is not prerendered, allowing runtime error testing.

- **Linting and Biome Configuration:**  
  - Updates `biome.json` to use the latest schema and improves rule coverage for style and code quality.
  - Refines file include/exclude patterns for more accurate linting.

- **Code Quality and Consistency:**  
  - Fixes import order and formatting in several files for consistency and to comply with linting rules.
  - Adds missing or reordered imports as required by the updated linter.

- **Other:**  
  - Updates `lint-staged` config in `package.json` for improved formatting.

**Summary:**  
These changes improve the developer experience, code quality, and maintainability of the Astro Prometheus Integration and its playground. No breaking changes to the integration API.